### PR TITLE
Remove Plug.Crypto dependency

### DIFF
--- a/lib/paginator.ex
+++ b/lib/paginator.ex
@@ -50,6 +50,10 @@ defmodule Paginator do
 
   alias Paginator.{Config, Cursor, Ecto.Query, Page, Page.Metadata}
 
+  defdelegate non_executable_binary_to_term(binary, opts \\ []),
+    to: Paginator.NonExecutableBinaryToTerm,
+    as: :decode
+
   defmacro __using__(opts) do
     quote do
       @defaults unquote(opts)

--- a/lib/paginator/cursor.ex
+++ b/lib/paginator/cursor.ex
@@ -6,7 +6,7 @@ defmodule Paginator.Cursor do
   def decode(encoded_cursor) do
     encoded_cursor
     |> Base.url_decode64!()
-    |> Plug.Crypto.non_executable_binary_to_term([:safe])
+    |> Paginator.non_executable_binary_to_term([:safe])
   end
 
   def encode(values) when is_map(values) do

--- a/lib/paginator/non_executable_binary_to_term.ex
+++ b/lib/paginator/non_executable_binary_to_term.ex
@@ -1,0 +1,85 @@
+defmodule Paginator.NonExecutableBinaryToTerm do
+  @moduledoc """
+  A restricted version of `:erlang.binary_to_term/2` that forbids
+  *executable* terms, such as anonymous functions.
+
+  This code is extracted from Plug.Crypto to avoid the dependency.
+  Original source: https://github.com/elixir-plug/plug_crypto
+  """
+
+  @doc """
+  Decodes a binary to a term, ensuring it contains no executable code.
+
+  The `opts` are given to the underlying `:erlang.binary_to_term/2`
+  call, with an empty list as a default.
+
+  By default this function does not restrict atoms, as an atom
+  interned in one node may not yet have been interned on another
+  (except for releases, which preload all code).
+
+  If you want to avoid atoms from being created, then you can pass
+  `[:safe]` as options, as that will also enable the safety mechanisms
+  from `:erlang.binary_to_term/2` itself.
+
+  ## Examples
+
+      iex> binary = :erlang.term_to_binary({:ok, [1, 2, 3]})
+      iex> Paginator.NonExecutableBinaryToTerm.decode(binary, [:safe])
+      {:ok, [1, 2, 3]}
+
+  """
+  @spec decode(binary(), [atom()]) :: term()
+  def decode(binary, opts \\ []) when is_binary(binary) do
+    term = :erlang.binary_to_term(binary, opts)
+    non_executable_terms(term)
+    term
+  end
+
+  defp non_executable_terms(list) when is_list(list) do
+    non_executable_list(list)
+  end
+
+  defp non_executable_terms(tuple) when is_tuple(tuple) do
+    non_executable_tuple(tuple, tuple_size(tuple))
+  end
+
+  defp non_executable_terms(map) when is_map(map) do
+    folder = fn key, value, acc ->
+      non_executable_terms(key)
+      non_executable_terms(value)
+      acc
+    end
+
+    :maps.fold(folder, map, map)
+  end
+
+  defp non_executable_terms(other)
+       when is_atom(other) or is_number(other) or is_bitstring(other) or is_pid(other) or
+              is_reference(other) do
+    other
+  end
+
+  defp non_executable_terms(other) do
+    raise ArgumentError,
+          "cannot deserialize #{inspect(other)}, the term is not safe for deserialization"
+  end
+
+  defp non_executable_list([]), do: :ok
+
+  defp non_executable_list([h | t]) when is_list(t) do
+    non_executable_terms(h)
+    non_executable_list(t)
+  end
+
+  defp non_executable_list([h | t]) do
+    non_executable_terms(h)
+    non_executable_terms(t)
+  end
+
+  defp non_executable_tuple(_tuple, 0), do: :ok
+
+  defp non_executable_tuple(tuple, n) do
+    non_executable_terms(:erlang.element(n, tuple))
+    non_executable_tuple(tuple, n - 1)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -39,8 +39,7 @@ defmodule Paginator.Mixfile do
       {:ex_doc, "~> 0.18", only: :dev, runtime: false},
       {:ex_machina, "~> 2.1", only: :test},
       {:inch_ex, "~> 2.0", only: [:dev, :test]},
-      {:postgrex, "~> 0.13", optional: true},
-      {:plug_crypto, "~> 2.1"}
+      {:postgrex, "~> 0.13", optional: true}
     ]
   end
 

--- a/test/paginator/non_executable_binary_to_term_test.exs
+++ b/test/paginator/non_executable_binary_to_term_test.exs
@@ -1,0 +1,76 @@
+defmodule Paginator.NonExecutableBinaryToTermTest do
+  use ExUnit.Case, async: true
+
+  alias Paginator.NonExecutableBinaryToTerm
+
+  describe "decode/2" do
+    test "decodes safe terms correctly" do
+      value = %{1 => {:foo, ["bar", 2.0, [self() | make_ref()], <<0::4>>]}}
+      binary = :erlang.term_to_binary(value)
+      assert NonExecutableBinaryToTerm.decode(binary) == value
+    end
+
+    test "decodes complex nested structures" do
+      value = %{
+        atoms: [:atom1, :atom2],
+        strings: ["string1", "string2"],
+        numbers: [1, 2, 3.14],
+        tuples: {:a, :b, :c},
+        maps: %{nested: %{key: "value"}},
+        lists: [[1, 2], [3, 4]]
+      }
+
+      binary = :erlang.term_to_binary(value)
+      assert NonExecutableBinaryToTerm.decode(binary) == value
+    end
+
+    test "decodes with :safe option" do
+      value = %{key: "value", number: 42}
+      binary = :erlang.term_to_binary(value)
+      assert NonExecutableBinaryToTerm.decode(binary, [:safe]) == value
+    end
+
+    test "raises ArgumentError for executable terms (anonymous functions)" do
+      binary = :erlang.term_to_binary(%{1 => {:foo, [fn -> :bar end]}})
+
+      assert_raise ArgumentError, ~r/cannot deserialize/, fn ->
+        NonExecutableBinaryToTerm.decode(binary)
+      end
+    end
+
+    test "raises ArgumentError with :safe option for new atoms" do
+      # This binary contains an atom that might not exist
+      binary = <<131, 100, 0, 7, 103, 114, 105, 102, 102, 105, 110>>
+
+      assert_raise ArgumentError, fn ->
+        NonExecutableBinaryToTerm.decode(binary, [:safe])
+      end
+    end
+
+    test "handles empty collections" do
+      assert NonExecutableBinaryToTerm.decode(:erlang.term_to_binary([])) == []
+      assert NonExecutableBinaryToTerm.decode(:erlang.term_to_binary({})) == {}
+      assert NonExecutableBinaryToTerm.decode(:erlang.term_to_binary(%{})) == %{}
+    end
+
+    test "handles pid and reference types" do
+      pid = self()
+      ref = make_ref()
+      value = %{pid: pid, ref: ref}
+      binary = :erlang.term_to_binary(value)
+      assert NonExecutableBinaryToTerm.decode(binary) == value
+    end
+
+    test "handles bitstrings" do
+      value = %{bitstring: <<1, 2, 3>>, aligned: <<0::4>>}
+      binary = :erlang.term_to_binary(value)
+      assert NonExecutableBinaryToTerm.decode(binary) == value
+    end
+
+    test "handles improper lists" do
+      value = [1, 2 | 3]
+      binary = :erlang.term_to_binary(value)
+      assert NonExecutableBinaryToTerm.decode(binary) == value
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Remove Plug.Crypto dependency by extracting and inlining the `non_executable_binary_to_term/2` function into a new `Paginator.NonExecutableBinaryToTerm` module
- Expose the function publicly via `defdelegate` in the main `Paginator` module for external use if needed

## Motivation

The library only uses a single function from Plug.Crypto (`non_executable_binary_to_term/2`). By extracting this function and its helper functions into our own module, we eliminate an external dependency, reducing the dependency footprint of the library.

## Changes

- Created new module `Paginator.NonExecutableBinaryToTerm` with the `decode/2` function (copied from Plug.Crypto with proper attribution)
- Added `defdelegate` in `Paginator` module to expose `non_executable_binary_to_term/2` publicly
- Updated `Paginator.Cursor` to use the new internal function instead of `Plug.Crypto`
- Removed `plug_crypto` from mix.exs dependencies

## Testing

All existing tests pass successfully, confirming that the functionality remains identical.